### PR TITLE
Pipeable dataFirst

### DIFF
--- a/packages/printer/src/Core/DocStream/index.ts
+++ b/packages/printer/src/Core/DocStream/index.ts
@@ -2,7 +2,7 @@
 
 import type { Array } from "@effect-ts/core/Array"
 import * as A from "@effect-ts/core/Array"
-import { identity, pipe } from "@effect-ts/core/Function"
+import { identity } from "@effect-ts/core/Function"
 import type { Identity } from "@effect-ts/core/Identity"
 import * as IO from "@effect-ts/core/IO"
 import type { Option } from "@effect-ts/core/Option"
@@ -299,7 +299,7 @@ export function unAnnotate<A>(stream: DocStream<A>): DocStream<never> {
           return empty
       }
     })
-  return pipe(go(stream), IO.run)
+  return IO.run(go(stream))
 }
 
 type AnnotationRemoval = "Remove" | "DontRemove"

--- a/packages/printer/src/Core/Layout/index.ts
+++ b/packages/printer/src/Core/Layout/index.ts
@@ -2,7 +2,7 @@
 
 import type { Array } from "@effect-ts/core/Array"
 import * as A from "@effect-ts/core/Array"
-import { constant, not, pipe } from "@effect-ts/core/Function"
+import { constant, not } from "@effect-ts/core/Function"
 import * as IO from "@effect-ts/core/IO"
 import type { Option } from "@effect-ts/core/Option"
 import * as O from "@effect-ts/core/Option"
@@ -317,26 +317,23 @@ function fitsPretty(width: number) {
  * line breaks.
  */
 export function pretty_<A>(options: LayoutOptions, doc: Doc<A>): DocStream<A> {
-  return pipe(
-    options.pageWidth,
-    PW.match({
-      AvailablePerLine: (lineWidth, ribbonFraction) =>
-        layoutWadlerLeijen(
-          doc,
-          (lineIndent, currentColumn) => {
-            const remainingWidth = PW.remainingWidth(
-              lineWidth,
-              ribbonFraction,
-              lineIndent,
-              currentColumn
-            )
-            return fitsPretty(remainingWidth)
-          },
-          options
-        ),
-      Unbounded: () => layoutUnbounded(doc)
-    })
-  )
+  return PW.match_(options.pageWidth, {
+    AvailablePerLine: (lineWidth, ribbonFraction) =>
+      layoutWadlerLeijen(
+        doc,
+        (lineIndent, currentColumn) => {
+          const remainingWidth = PW.remainingWidth(
+            lineWidth,
+            ribbonFraction,
+            lineIndent,
+            currentColumn
+          )
+          return fitsPretty(remainingWidth)
+        },
+        options
+      ),
+    Unbounded: () => layoutUnbounded(doc)
+  })
 }
 
 /**
@@ -488,14 +485,11 @@ function fitsSmart(lineWidth: number, ribbonFraction: number) {
  * ```
  */
 export function smart_<A>(options: LayoutOptions, doc: Doc<A>): DocStream<A> {
-  return pipe(
-    options.pageWidth,
-    PW.match({
-      AvailablePerLine: (lineWidth, ribbonFraction) =>
-        layoutWadlerLeijen(doc, fitsSmart(lineWidth, ribbonFraction), options),
-      Unbounded: () => layoutUnbounded(doc)
-    })
-  )
+  return PW.match_(options.pageWidth, {
+    AvailablePerLine: (lineWidth, ribbonFraction) =>
+      layoutWadlerLeijen(doc, fitsSmart(lineWidth, ribbonFraction), options),
+    Unbounded: () => layoutUnbounded(doc)
+  })
 }
 
 /**

--- a/packages/printer/src/Core/Optimize/index.ts
+++ b/packages/printer/src/Core/Optimize/index.ts
@@ -83,7 +83,7 @@ export const Deep: FusionDepth = "Deep"
  * It is therefore a good idea to run `fuse` on concatenations of lots of small
  * strings that are used many times.
  */
-export const optimize = <A>(doc: Doc<A>): Optimize<A> => {
+export function optimize<A>(doc: Doc<A>): Optimize<A> {
   function go(x: Doc<A>, depth: FusionDepth): S.IO<Doc<A>> {
     return S.gen(function* (_) {
       yield* _(S.unit)

--- a/packages/printer/src/Core/Optimize/index.ts
+++ b/packages/printer/src/Core/Optimize/index.ts
@@ -90,7 +90,7 @@ export const optimize = <A>(doc: Doc<A>): Optimize<A> => {
 
       switch (x._tag) {
         case "FlatAlt": {
-          return D.flatAlt(yield* _(go(x.left, depth)), yield* _(go(x.right, depth)))
+          return D.flatAlt_(yield* _(go(x.left, depth)), yield* _(go(x.right, depth)))
         }
         case "Cat": {
           // Empty documents
@@ -116,30 +116,30 @@ export const optimize = <A>(doc: Doc<A>): Optimize<A> => {
           }
           // Nested strings
           if (D.isChar(x.left) && D.isCat(x.right) && D.isChar(x.right.left)) {
-            const inner = yield* _(go(D.cat(x.left, x.right.left), depth))
-            return yield* _(go(D.cat(inner, x.right.right), depth))
+            const inner = yield* _(go(D.cat_(x.left, x.right.left), depth))
+            return yield* _(go(D.cat_(inner, x.right.right), depth))
           }
           if (D.isText(x.left) && D.isCat(x.right) && D.isChar(x.right.left)) {
-            const inner = yield* _(go(D.cat(x.left, x.right.left), depth))
-            return yield* _(go(D.cat(inner, x.right.right), depth))
+            const inner = yield* _(go(D.cat_(x.left, x.right.left), depth))
+            return yield* _(go(D.cat_(inner, x.right.right), depth))
           }
           if (D.isChar(x.left) && D.isCat(x.right) && D.isText(x.right.left)) {
-            const inner = yield* _(go(D.cat(x.left, x.right.left), depth))
-            return yield* _(go(D.cat(inner, x.right.right), depth))
+            const inner = yield* _(go(D.cat_(x.left, x.right.left), depth))
+            return yield* _(go(D.cat_(inner, x.right.right), depth))
           }
           if (D.isText(x.left) && D.isCat(x.right) && D.isText(x.right.left)) {
-            const inner = yield* _(go(D.cat(x.left, x.right.left), depth))
-            return yield* _(go(D.cat(inner, x.right.right), depth))
+            const inner = yield* _(go(D.cat_(x.left, x.right.left), depth))
+            return yield* _(go(D.cat_(inner, x.right.right), depth))
           }
           if (D.isCat(x.left) && D.isChar(x.right)) {
-            const inner = yield* _(go(D.cat(x.left.right, x.right), depth))
-            return yield* _(go(D.cat(x.left.left, inner), depth))
+            const inner = yield* _(go(D.cat_(x.left.right, x.right), depth))
+            return yield* _(go(D.cat_(x.left.left, inner), depth))
           }
           if (D.isCat(x.left) && D.isText(x.left.right)) {
-            const inner = yield* _(go(D.cat(x.left.right, x.right), depth))
-            return yield* _(go(D.cat(x.left.left, inner), depth))
+            const inner = yield* _(go(D.cat_(x.left.right, x.right), depth))
+            return yield* _(go(D.cat_(x.left.left, inner), depth))
           }
-          return D.cat(yield* _(go(x.left, depth)), yield* _(go(x.right, depth)))
+          return D.cat_(yield* _(go(x.left, depth)), yield* _(go(x.right, depth)))
         }
         case "Nest": {
           if (D.isEmpty(x.doc)) return x.doc
@@ -152,7 +152,7 @@ export const optimize = <A>(doc: Doc<A>): Optimize<A> => {
           return D.nest(x.indent)(yield* _(go(x.doc, depth)))
         }
         case "Union": {
-          return D.union(yield* _(go(x.left, depth)), yield* _(go(x.right, depth)))
+          return D.union_(yield* _(go(x.left, depth)), yield* _(go(x.right, depth)))
         }
         case "Column": {
           return depth === Shallow
@@ -170,7 +170,7 @@ export const optimize = <A>(doc: Doc<A>): Optimize<A> => {
             : D.nesting((level) => S.run(go(x.react(level), depth)))
         }
         case "Annotated": {
-          return D.annotate(x.annotation, yield* _(go(x.doc, depth)))
+          return D.annotate_(yield* _(go(x.doc, depth)), x.annotation)
         }
         default:
           return x

--- a/packages/printer/src/Core/Render/index.ts
+++ b/packages/printer/src/Core/Render/index.ts
@@ -4,39 +4,41 @@ import * as IO from "@effect-ts/core/IO"
 
 import type { DocStream } from "../DocStream"
 
+function renderRec<A>(x: DocStream<A>): IO.IO<string> {
+  return IO.gen(function* (_) {
+    switch (x._tag) {
+      case "FailedStream":
+        throw new Error("bug, we ended up with a failed in render!")
+      case "EmptyStream":
+        return ""
+      case "CharStream": {
+        const rest = yield* _(renderRec(x.stream))
+        return x.char + rest
+      }
+      case "TextStream": {
+        const rest = yield* _(renderRec(x.stream))
+        return x.text + rest
+      }
+      case "LineStream": {
+        let indent = "\n"
+        for (let i = 1; i < x.indentation; i++) {
+          indent = indent += " "
+        }
+        const rest = yield* _(renderRec(x.stream))
+        return indent + rest
+      }
+      case "PushAnnotationStream":
+        return yield* _(renderRec(x.stream))
+      case "PopAnnotationStream":
+        return yield* _(renderRec(x.stream))
+    }
+  })
+}
+
 // -------------------------------------------------------------------------------------
 // operations
 // -------------------------------------------------------------------------------------
 
 export const render = <A>(stream: DocStream<A>): string => {
-  const go = (x: DocStream<A>): IO.IO<string> =>
-    IO.gen(function* (_) {
-      switch (x._tag) {
-        case "FailedStream":
-          throw new Error("bug, we ended up with a failed in render!")
-        case "EmptyStream":
-          return ""
-        case "CharStream": {
-          const rest = yield* _(go(x.stream))
-          return x.char + rest
-        }
-        case "TextStream": {
-          const rest = yield* _(go(x.stream))
-          return x.text + rest
-        }
-        case "LineStream": {
-          let indent = "\n"
-          for (let i = 1; i < x.indentation; i++) {
-            indent = indent += " "
-          }
-          const rest = yield* _(go(x.stream))
-          return indent + rest
-        }
-        case "PushAnnotationStream":
-          return yield* _(go(x.stream))
-        case "PopAnnotationStream":
-          return yield* _(go(x.stream))
-      }
-    })
-  return IO.run(go(stream))
+  return IO.run(renderRec(stream))
 }


### PR DESCRIPTION
Applies convention: for every pipeable function a data-first counter should exist and be named with a _ at the end, and the comment `@dataFirst name_` should be added in the pipeable version.

This is necessary for the compiler plugin to rewrite (after unpipe) the pipeable variants to data-first (more performant).

This PR only adds convention to `Doc` the remaining modules should follow the same pattern