### PR TITLE
Feature/test suite

### DIFF
--- a/packages/printer/src/Core/Doc/index.ts
+++ b/packages/printer/src/Core/Doc/index.ts
@@ -1420,6 +1420,15 @@ export const seps: <A>(docs: Array<Doc<A>>) => Doc<A> = (_) => group(vsep(_))
 export const hcat: <A>(docs: Array<Doc<A>>) => Doc<A> = concatWith(cat_)
 
 /**
+ * Tupled variant of `hcat`.
+ */
+export function hcatT<Docs extends Array<Doc<any>>>(
+  ...docs: Docs
+): Doc<_A<Docs[number]>> {
+  return hcat(docs)
+}
+
+/**
  * The `vcat` combinator concatenates all documents in a list vertically. If the
  * output is grouped then the line breaks are removed.
  *
@@ -1482,7 +1491,7 @@ export function cats<A>(docs: Array<Doc<A>>): Doc<A> {
 }
 
 /**
- * Tupled variant of cats
+ * Tupled variant of `cats`.
  */
 export function catsT<Docs extends Array<Doc<any>>>(
   ...docs: Docs

--- a/packages/printer/src/Core/Doc/index.ts
+++ b/packages/printer/src/Core/Doc/index.ts
@@ -253,7 +253,9 @@ export function text(text: string): Doc<never> {
 }
 
 /**
- * A document containing a string of text.
+ * A document containing a string of text. Newline characters (`\n`)
+ * contained in the provided string will be disregarded (i.e. not
+ * rendered) in the output document.
  */
 export function string(str: string): Doc<never> {
   return cats(
@@ -577,9 +579,9 @@ export function nesting<A>(react: (level: number) => Doc<A>): Doc<A> {
  *
  * const doc = D.hsep([
  *   D.text('prefix'),
- *   D.pageWidth(
+ *   D.withPageWidth(
  *     PW.match({
- *       AvailablePerLine: (lw, rf) => D.brackets(D.text(`Width: ${lw}, ribbon fraction: ${rf}`)),
+ *       AvailablePerLine: (lw, rf) => D.brackets(D.text(`Width: ${lw}, Ribbon Fraction: ${rf}`)),
  *       Unbounded: () => D.empty
  *     })
  *   )
@@ -588,9 +590,9 @@ export function nesting<A>(react: (level: number) => Doc<A>): Doc<A> {
  * const example = D.vsep(A.map_([0, 4, 8], (n) => D.indent_(doc, n)))
  *
  * console.log(pipe(example, R.renderPretty(32)))
- * // prefix [Width: 32, ribbon fraction: 1]
- * //     prefix [Width: 32, ribbon fraction: 1]
- * //         prefix [Width: 32, ribbon fraction: 1]
+ * // prefix [Width: 32, Ribbon Fraction: 1]
+ * //     prefix [Width: 32, Ribbon Fraction: 1]
+ * //         prefix [Width: 32, Ribbon Fraction: 1]
  * ```
  */
 export function withPageWidth<A>(react: (pageWidth: PageWidth) => Doc<A>): Doc<A> {

--- a/packages/printer/src/Core/Doc/index.ts
+++ b/packages/printer/src/Core/Doc/index.ts
@@ -1185,6 +1185,10 @@ const flatten = <A>(doc: Doc<A>): Doc<A> => {
 function changesUponFlatteningRec<A>(x: Doc<A>): IO.IO<Flatten<Doc<A>>> {
   return IO.gen(function* (_) {
     switch (x._tag) {
+      case "Fail":
+        return F.neverFlat
+      case "Line":
+        return F.neverFlat
       case "FlatAlt":
         return F.flattened(flatten(x.right))
       case "Cat": {
@@ -1366,7 +1370,7 @@ export const fillSep: <A>(docs: Array<Doc<A>>) => Doc<A> = concatWith(
 )
 
 /**
- * The `sep` combinator will attempt to lay out a list of documents separated by `space`s.
+ * The `seps` combinator will attempt to lay out a list of documents separated by `space`s.
  * If the output does not fit the page, then the documents will be separated by newlines.
  * This is what differentiates it from `vsep`, which always lays out documents beneath one
  * another.
@@ -1378,7 +1382,7 @@ export const fillSep: <A>(docs: Array<Doc<A>>) => Doc<A> = concatWith(
  *
  * const doc = D.hsep([
  *   D.text('prefix'),
- *   D.sep(D.words('text to lay out'))
+ *   D.seps(D.words('text to lay out'))
  * ])
  *
  * console.log(R.renderPrettyDefault(doc))
@@ -1435,7 +1439,7 @@ export const vcat: <A>(docs: Array<Doc<A>>) => Doc<A> = concatWith(appendWithLin
 
 /**
  * The `fillCat` combinator concatenates all documents in a list horizontally by placing
- * a `space` between each pair of documents as long as they fit the page. Once the page
+ * a `empty` between each pair of documents as long as they fit the page. Once the page
  * width is exceeded, a `lineBreak` is inserted and the process is repeated for all
  * documents in the list.
  *
@@ -1447,7 +1451,7 @@ export const fillCat: <A>(docs: Array<Doc<A>>) => Doc<A> = concatWith(
 )
 
 /**
- * The `cat` combinator will attempt to lay out a list of documents separated by nothing.
+ * The `cats` combinator will attempt to lay out a list of documents separated by nothing.
  * If the output does not fit the page, then the documents will be separated by newlines.
  * This is what differentiates it from `vcat`, which always lays out documents beneath one
  * another.
@@ -1459,7 +1463,7 @@ export const fillCat: <A>(docs: Array<Doc<A>>) => Doc<A> = concatWith(
  *
  * const doc = D.hsep([
  *   D.text('Docs:'),
- *   D.cat(D.words('lorem ipsum dolor'))
+ *   D.cats(D.words('lorem ipsum dolor'))
  * ])
  *
  * console.log(R.renderPrettyDefault(doc))
@@ -1517,7 +1521,7 @@ export function catsT<Docs extends Array<Doc<any>>>(
  *
  * console.log(R.renderPrettyDefault(doc))
  * // let empty :: Doc
- * //     nest :: Int -> Doc -> Doc
+ * //     nest  :: Int -> Doc -> Doc
  * //     fillSep :: [Doc] -> Doc
  * ```
  *
@@ -1563,9 +1567,9 @@ export function fill_<A>(doc: Doc<A>, width: number): Doc<A> {
  *
  * console.log(R.renderPrettyDefault(doc))
  * // let empty :: Doc
- * //     nest :: Int -> Doc -> Doc
+ * //     nest  :: Int -> Doc -> Doc
  * //     fillSep
- * //          :: [Doc] -> Doc
+ * //           :: [Doc] -> Doc
  * ```
  *
  * @dataFirst fillBreak_
@@ -2034,7 +2038,7 @@ export function spaces(n: number): Doc<never> {
  * import * as D from '@effect-ts/printer/Core/Doc'
  * import * as R from '@effect-ts/printer/Core/Render'
  *
- * const doc = D.tupled(D.words('Lorem ipsum dolor'))
+ * const doc = D.tupled(D.words('lorem ipsum dolor'))
  *
  * console.log(R.renderPrettyDefault(doc))
  * // (lorem, ipsum, dolor)
@@ -2061,7 +2065,7 @@ export function words(s: string, char = " "): Array<Doc<never>> {
  *     'sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
  * )
  *
- * console.log(pipe(doc, R.renderWidth(32)))
+ * console.log(pipe(doc, R.renderPretty(32)))
  * // Lorem ipsum dolor sit amet,
  * // consectetur adipisicing elit,
  * // sed do eiusmod tempor incididunt

--- a/packages/printer/src/Core/DocStream/index.ts
+++ b/packages/printer/src/Core/DocStream/index.ts
@@ -211,7 +211,7 @@ export function match<A, R>(patterns: {
 // operations
 // -------------------------------------------------------------------------------------
 
-export function isFailed<A>(stream: DocStream<A>): stream is FailedStream<A> {
+export function isFailedStream<A>(stream: DocStream<A>): stream is FailedStream<A> {
   return stream._tag === "FailedStream"
 }
 
@@ -231,13 +231,13 @@ export function isLineStream<A>(stream: DocStream<A>): stream is LineStream<A> {
   return stream._tag === "LineStream"
 }
 
-export function isPushAnnotation<A>(
+export function isPushAnnotationStream<A>(
   stream: DocStream<A>
 ): stream is PushAnnotationStream<A> {
   return stream._tag === "PushAnnotationStream"
 }
 
-export function isPopAnnotation<A>(
+export function isPopAnnotationStream<A>(
   stream: DocStream<A>
 ): stream is PopAnnotationStream<A> {
   return stream._tag === "PopAnnotationStream"

--- a/packages/printer/src/Core/Layout/index.ts
+++ b/packages/printer/src/Core/Layout/index.ts
@@ -306,10 +306,10 @@ function failsOnFirstLine<A>(stream: DocStream<A>): boolean {
 }
 
 /**
- * The `layoutUnbounded` layout algorithm will lay out a document an
+ * The `unbounded` layout algorithm will lay out a document an
  * `Unbounded` page width.
  */
-export function layoutUnbounded<A>(doc: Doc<A>): DocStream<A> {
+export function unbounded<A>(doc: Doc<A>): DocStream<A> {
   return layoutWadlerLeijen<A>(
     doc,
     constant(not(failsOnFirstLine)),
@@ -373,7 +373,7 @@ export function pretty_<A>(options: LayoutOptions, doc: Doc<A>): DocStream<A> {
         },
         options
       ),
-    Unbounded: () => layoutUnbounded(doc)
+    Unbounded: () => unbounded(doc)
   })(options.pageWidth)
 }
 
@@ -526,7 +526,7 @@ export function smart_<A>(options: LayoutOptions, doc: Doc<A>): DocStream<A> {
   return PW.PageWidth.matchStrict({
     AvailablePerLine: ({ lineWidth, ribbonFraction }) =>
       layoutWadlerLeijen(doc, fitsSmart(lineWidth, ribbonFraction), options),
-    Unbounded: () => layoutUnbounded(doc)
+    Unbounded: () => unbounded(doc)
   })(options.pageWidth)
 }
 

--- a/packages/printer/src/Core/Layout/index.ts
+++ b/packages/printer/src/Core/Layout/index.ts
@@ -358,8 +358,8 @@ function fitsPretty(width: number) {
  * line breaks.
  */
 export function pretty_<A>(options: LayoutOptions, doc: Doc<A>): DocStream<A> {
-  return PW.match_(options.pageWidth, {
-    AvailablePerLine: (lineWidth, ribbonFraction) =>
+  return PW.PageWidth.matchStrict({
+    AvailablePerLine: ({ lineWidth, ribbonFraction }) =>
       layoutWadlerLeijen(
         doc,
         (lineIndent, currentColumn) => {
@@ -374,7 +374,7 @@ export function pretty_<A>(options: LayoutOptions, doc: Doc<A>): DocStream<A> {
         options
       ),
     Unbounded: () => layoutUnbounded(doc)
-  })
+  })(options.pageWidth)
 }
 
 /**
@@ -523,11 +523,11 @@ function fitsSmart(lineWidth: number, ribbonFraction: number) {
  * ```
  */
 export function smart_<A>(options: LayoutOptions, doc: Doc<A>): DocStream<A> {
-  return PW.match_(options.pageWidth, {
-    AvailablePerLine: (lineWidth, ribbonFraction) =>
+  return PW.PageWidth.matchStrict({
+    AvailablePerLine: ({ lineWidth, ribbonFraction }) =>
       layoutWadlerLeijen(doc, fitsSmart(lineWidth, ribbonFraction), options),
     Unbounded: () => layoutUnbounded(doc)
-  })
+  })(options.pageWidth)
 }
 
 /**

--- a/packages/printer/src/Core/Optimize/index.ts
+++ b/packages/printer/src/Core/Optimize/index.ts
@@ -1,6 +1,6 @@
 // tracing: off
 
-import * as S from "@effect-ts/core/IO"
+import * as IO from "@effect-ts/core/IO"
 
 import type { Doc } from "../Doc"
 import * as D from "../Doc"
@@ -52,6 +52,114 @@ export const Deep: FusionDepth = "Deep"
 // operations
 // -------------------------------------------------------------------------------------
 
+function optimizeRec<A>(x: Doc<A>, depth: FusionDepth): IO.IO<Doc<A>> {
+  return IO.gen(function* (_) {
+    switch (x._tag) {
+      case "FlatAlt": {
+        return D.flatAlt_(
+          yield* _(optimizeRec(x.left, depth)),
+          yield* _(optimizeRec(x.right, depth))
+        )
+      }
+      case "Cat": {
+        // Empty documents
+        if (D.isEmpty(x.left)) {
+          return yield* _(optimizeRec(x.right, depth))
+        }
+        if (D.isEmpty(x.right)) {
+          return yield* _(optimizeRec(x.left, depth))
+        }
+
+        // String documents
+        if (D.isChar(x.left) && D.isChar(x.right)) {
+          return D.text(x.left.char + x.right.char)
+        }
+        if (D.isText(x.left) && D.isChar(x.right)) {
+          return D.text(x.left.text + x.right.char)
+        }
+        if (D.isChar(x.left) && D.isText(x.right)) {
+          return D.text(x.left.char + x.right.text)
+        }
+        if (D.isText(x.left) && D.isText(x.right)) {
+          return D.text(x.left.text + x.right.text)
+        }
+        // Nested strings
+        if (D.isChar(x.left) && D.isCat(x.right) && D.isChar(x.right.left)) {
+          const inner = yield* _(optimizeRec(D.cat_(x.left, x.right.left), depth))
+          return yield* _(optimizeRec(D.cat_(inner, x.right.right), depth))
+        }
+        if (D.isText(x.left) && D.isCat(x.right) && D.isChar(x.right.left)) {
+          const inner = yield* _(optimizeRec(D.cat_(x.left, x.right.left), depth))
+          return yield* _(optimizeRec(D.cat_(inner, x.right.right), depth))
+        }
+        if (D.isChar(x.left) && D.isCat(x.right) && D.isText(x.right.left)) {
+          const inner = yield* _(optimizeRec(D.cat_(x.left, x.right.left), depth))
+          return yield* _(optimizeRec(D.cat_(inner, x.right.right), depth))
+        }
+        if (D.isText(x.left) && D.isCat(x.right) && D.isText(x.right.left)) {
+          const inner = yield* _(optimizeRec(D.cat_(x.left, x.right.left), depth))
+          return yield* _(optimizeRec(D.cat_(inner, x.right.right), depth))
+        }
+        if (D.isCat(x.left) && D.isChar(x.right)) {
+          const inner = yield* _(optimizeRec(D.cat_(x.left.right, x.right), depth))
+          return yield* _(optimizeRec(D.cat_(x.left.left, inner), depth))
+        }
+        if (D.isCat(x.left) && D.isText(x.left.right)) {
+          const inner = yield* _(optimizeRec(D.cat_(x.left.right, x.right), depth))
+          return yield* _(optimizeRec(D.cat_(x.left.left, inner), depth))
+        }
+        const inner = D.cat_(
+          yield* _(optimizeRec(x.left, depth)),
+          yield* _(optimizeRec(x.right, depth))
+        )
+        return yield* _(optimizeRec(inner, depth))
+      }
+      case "Nest": {
+        if (D.isEmpty(x.doc)) return x.doc
+        if (D.isChar(x.doc)) return x.doc
+        if (D.isText(x.doc)) return x.doc
+        if (D.isNest(x.doc)) {
+          return yield* _(optimizeRec(D.nest_(x.doc, x.indent + x.doc.indent), depth))
+        }
+        if (x.indent === 0) return yield* _(optimizeRec(x.doc, depth))
+        return D.nest_(yield* _(optimizeRec(x.doc, depth)), x.indent)
+      }
+      case "Union": {
+        return D.union_(
+          yield* _(optimizeRec(x.left, depth)),
+          yield* _(optimizeRec(x.right, depth))
+        )
+      }
+      case "Column": {
+        return depth === Shallow
+          ? D.column(x.react)
+          : D.column((position) => IO.run(optimizeRec(x.react(position), depth)))
+      }
+      case "WithPageWidth": {
+        return depth === Shallow
+          ? D.withPageWidth(x.react)
+          : D.withPageWidth((pageWidth) =>
+              IO.run(optimizeRec(x.react(pageWidth), depth))
+            )
+      }
+      case "Nesting": {
+        return depth === Shallow
+          ? D.nesting(x.react)
+          : D.nesting((level) => IO.run(optimizeRec(x.react(level), depth)))
+      }
+      case "Annotated": {
+        return D.annotate_(yield* _(optimizeRec(x.doc, depth)), x.annotation)
+      }
+      default:
+        return x
+    }
+  })
+}
+
+export function optimize_<A>(depth: FusionDepth, doc: Doc<A>): Doc<A> {
+  return IO.run(optimizeRec(doc, depth))
+}
+
 /**
  * The `optimizer` will combine text nodes so that they can be rendered more
  * efficiently. An optimized document is always laid out in an identical manner to its
@@ -68,7 +176,7 @@ export const Deep: FusionDepth = "Deep"
  * import * as D from "../src/Core/Doc"
  *
  * // The document below contains a chain of four entries in the output `DocStream`
- * const doc1 = D.catsT(D.char("a"), D.char("b"), D.char("c"), D.char("d"))
+ * const doc1 = D.hsepT(D.char("a"), D.char("b"), D.char("c"), D.char("d"))
  *
  * // but is fully equivalent to the tightly packed document below which is only
  * // a single entry in the output `DocStream` and can be processed much more
@@ -77,98 +185,5 @@ export const Deep: FusionDepth = "Deep"
  * ```
  */
 export function optimize<A>(doc: Doc<A>): Optimize<A> {
-  function go(x: Doc<A>, depth: FusionDepth): S.IO<Doc<A>> {
-    return S.gen(function* (_) {
-      yield* _(S.unit)
-
-      switch (x._tag) {
-        case "FlatAlt": {
-          return D.flatAlt_(yield* _(go(x.left, depth)), yield* _(go(x.right, depth)))
-        }
-        case "Cat": {
-          // Empty documents
-          if (D.isEmpty(x.left)) {
-            return yield* _(go(x.right, depth))
-          }
-          if (D.isEmpty(x.right)) {
-            return yield* _(go(x.left, depth))
-          }
-
-          // String documents
-          if (D.isChar(x.left) && D.isChar(x.right)) {
-            return D.text(x.left.char + x.right.char)
-          }
-          if (D.isText(x.left) && D.isChar(x.right)) {
-            return D.text(x.left.text + x.right.char)
-          }
-          if (D.isChar(x.left) && D.isText(x.right)) {
-            return D.text(x.left.char + x.right.text)
-          }
-          if (D.isText(x.left) && D.isText(x.right)) {
-            return D.text(x.left.text + x.right.text)
-          }
-          // Nested strings
-          if (D.isChar(x.left) && D.isCat(x.right) && D.isChar(x.right.left)) {
-            const inner = yield* _(go(D.cat_(x.left, x.right.left), depth))
-            return yield* _(go(D.cat_(inner, x.right.right), depth))
-          }
-          if (D.isText(x.left) && D.isCat(x.right) && D.isChar(x.right.left)) {
-            const inner = yield* _(go(D.cat_(x.left, x.right.left), depth))
-            return yield* _(go(D.cat_(inner, x.right.right), depth))
-          }
-          if (D.isChar(x.left) && D.isCat(x.right) && D.isText(x.right.left)) {
-            const inner = yield* _(go(D.cat_(x.left, x.right.left), depth))
-            return yield* _(go(D.cat_(inner, x.right.right), depth))
-          }
-          if (D.isText(x.left) && D.isCat(x.right) && D.isText(x.right.left)) {
-            const inner = yield* _(go(D.cat_(x.left, x.right.left), depth))
-            return yield* _(go(D.cat_(inner, x.right.right), depth))
-          }
-          if (D.isCat(x.left) && D.isChar(x.right)) {
-            const inner = yield* _(go(D.cat_(x.left.right, x.right), depth))
-            return yield* _(go(D.cat_(x.left.left, inner), depth))
-          }
-          if (D.isCat(x.left) && D.isText(x.left.right)) {
-            const inner = yield* _(go(D.cat_(x.left.right, x.right), depth))
-            return yield* _(go(D.cat_(x.left.left, inner), depth))
-          }
-          return D.cat_(yield* _(go(x.left, depth)), yield* _(go(x.right, depth)))
-        }
-        case "Nest": {
-          if (D.isEmpty(x.doc)) return x.doc
-          if (D.isChar(x.doc)) return x.doc
-          if (D.isText(x.doc)) return x.doc
-          if (D.isNest(x.doc)) {
-            return yield* _(go(D.nest(x.indent + x.doc.indent)(x.doc), depth))
-          }
-          if (x.indent === 0) return yield* _(go(x.doc, depth))
-          return D.nest(x.indent)(yield* _(go(x.doc, depth)))
-        }
-        case "Union": {
-          return D.union_(yield* _(go(x.left, depth)), yield* _(go(x.right, depth)))
-        }
-        case "Column": {
-          return depth === Shallow
-            ? D.column(x.react)
-            : D.column((position) => S.run(go(x.react(position), depth)))
-        }
-        case "WithPageWidth": {
-          return depth === Shallow
-            ? D.withPageWidth(x.react)
-            : D.withPageWidth((pageWidth) => S.run(go(x.react(pageWidth), depth)))
-        }
-        case "Nesting": {
-          return depth === Shallow
-            ? D.nesting(x.react)
-            : D.nesting((level) => S.run(go(x.react(level), depth)))
-        }
-        case "Annotated": {
-          return D.annotate_(yield* _(go(x.doc, depth)), x.annotation)
-        }
-        default:
-          return x
-      }
-    })
-  }
-  return (_) => S.run(go(doc, _))
+  return (depth) => optimize_(depth, doc)
 }

--- a/packages/printer/src/Core/PageWidth/index.ts
+++ b/packages/printer/src/Core/PageWidth/index.ts
@@ -76,35 +76,6 @@ export const unbounded: PageWidth = PageWidth.as.Unbounded({})
 export const defaultPageWidth = availablePerLine(80, 1)
 
 // -------------------------------------------------------------------------------------
-// destructors
-// -------------------------------------------------------------------------------------
-
-export function match_<R>(
-  pageWidth: PageWidth,
-  patterns: {
-    readonly AvailablePerLine: (lineWidth: number, ribbonFraction: number) => R
-    readonly Unbounded: () => R
-  }
-): R {
-  switch (pageWidth._tag) {
-    case "AvailablePerLine":
-      return patterns.AvailablePerLine(pageWidth.lineWidth, pageWidth.ribbonFraction)
-    case "Unbounded":
-      return patterns.Unbounded()
-  }
-}
-
-/**
- * @dataFirst match_
- */
-export function match<R>(patterns: {
-  readonly AvailablePerLine: (lineWidth: number, ribbonFraction: number) => R
-  readonly Unbounded: () => R
-}) {
-  return (pageWidth: PageWidth): R => match_(pageWidth, patterns)
-}
-
-// -------------------------------------------------------------------------------------
 // operations
 // -------------------------------------------------------------------------------------
 

--- a/packages/printer/src/Core/Render/index.ts
+++ b/packages/printer/src/Core/Render/index.ts
@@ -39,7 +39,7 @@ function renderRec<A>(x: DocStream<A>): IO.IO<string> {
 }
 
 // -------------------------------------------------------------------------------------
-// operations
+// rendering algorithms
 // -------------------------------------------------------------------------------------
 
 export function render<A>(stream: DocStream<A>): string {

--- a/packages/printer/test/doc.test.ts
+++ b/packages/printer/test/doc.test.ts
@@ -191,9 +191,11 @@ prefix [Nested: 0]
       const prefix = D.hsep([
         D.text("prefix"),
         D.withPageWidth(
-          PW.match({
-            AvailablePerLine: (lw, rf) =>
-              D.brackets(D.text(`Width: ${lw}, Ribbon Fraction: ${rf}`)),
+          PW.PageWidth.matchStrict({
+            AvailablePerLine: ({ lineWidth, ribbonFraction }) =>
+              D.brackets(
+                D.text(`Width: ${lineWidth}, Ribbon Fraction: ${ribbonFraction}`)
+              ),
             Unbounded: () => D.empty
           })
         )

--- a/packages/printer/test/doc.test.ts
+++ b/packages/printer/test/doc.test.ts
@@ -1,23 +1,436 @@
-import { pipe } from "@effect-ts/system/Function"
+import type { Array } from "@effect-ts/core/Array"
+import * as A from "@effect-ts/core/Array"
+import { constant, identity, pipe } from "@effect-ts/system/Function"
 
+import type { Doc } from "../src/Core/Doc"
 import * as D from "../src/Core/Doc"
-import * as L from "../src/Core/Layout"
+import * as PW from "../src/Core/PageWidth"
 import * as R from "../src/Core/Render"
 
 describe("Doc", () => {
-  it("dummy", () => {
-    expect(
-      pipe(
-        D.catsT(
-          D.text("hello"),
-          D.text("world"),
-          D.char("I"),
-          D.text("am"),
-          D.text("alive")
-        ),
-        L.compact,
-        R.render
+  describe("definition", () => {
+    it("Fail", () => {
+      const doc = new D.Fail(identity)
+
+      expect(doc).toBeInstanceOf(D.Fail)
+      expect(doc.id).toBeDefined()
+    })
+
+    it("Char", () => {
+      const doc = new D.Char("a", identity)
+
+      expect(doc).toBeInstanceOf(D.Char)
+      expect(doc.id).toBeDefined()
+      expect(doc.char).toBe("a")
+    })
+
+    it("Text", () => {
+      const doc = new D.Text("foo", identity)
+
+      expect(doc).toBeInstanceOf(D.Text)
+      expect(doc.id).toBeDefined()
+      expect(doc.text).toBe("foo")
+    })
+
+    it("FlatAlt", () => {
+      const doc = new D.FlatAlt(new D.Char("a", identity), new D.Char("b", identity))
+
+      expect(doc).toBeInstanceOf(D.FlatAlt)
+      expect(doc.left).toBeInstanceOf(D.Char)
+      expect(doc.left).toHaveProperty("char", "a")
+      expect(doc.right).toBeInstanceOf(D.Char)
+      expect(doc.right).toHaveProperty("char", "b")
+    })
+
+    it("Cat", () => {
+      const doc = new D.Cat(new D.Char("a", identity), new D.Char("b", identity))
+
+      expect(doc).toBeInstanceOf(D.Cat)
+      expect(doc.left).toBeInstanceOf(D.Char)
+      expect(doc.left).toHaveProperty("char", "a")
+      expect(doc.right).toBeInstanceOf(D.Char)
+      expect(doc.right).toHaveProperty("char", "b")
+    })
+
+    it("Nest", () => {
+      const doc = new D.Nest(4, new D.Char("a", identity))
+
+      expect(doc).toBeInstanceOf(D.Nest)
+      expect(doc.doc).toBeInstanceOf(D.Char)
+      expect(doc.doc).toHaveProperty("char", "a")
+      expect(doc.indent).toBe(4)
+    })
+
+    it("Union", () => {
+      const doc = new D.Union(new D.Char("a", identity), new D.Char("b", identity))
+
+      expect(doc).toBeInstanceOf(D.Union)
+      expect(doc.left).toBeInstanceOf(D.Char)
+      expect(doc.left).toHaveProperty("char", "a")
+      expect(doc.right).toBeInstanceOf(D.Char)
+      expect(doc.right).toHaveProperty("char", "b")
+    })
+
+    it("Column", () => {
+      const doc = new D.Column((pos) => new D.Text(`${pos}`, identity))
+      const reactedDoc = doc.react(4)
+
+      expect(doc).toBeInstanceOf(D.Column)
+      expect(doc.react).toBeDefined()
+      expect(reactedDoc).toBeInstanceOf(D.Text)
+      expect(reactedDoc).toHaveProperty("text", "4")
+    })
+
+    it("WithPageWidth", () => {
+      const react = (w: PW.PageWidth): D.Doc<never> =>
+        w._tag === "AvailablePerLine"
+          ? new D.Text(`${w.lineWidth}`, identity)
+          : new D.Char("a", identity)
+      const doc = new D.WithPageWidth(react)
+      const availablePerLineDoc = doc.react(PW.availablePerLine(80, 1))
+      const unboundedDoc = doc.react(PW.unbounded)
+
+      expect(doc).toBeInstanceOf(D.WithPageWidth)
+      expect(doc.react).toBeDefined()
+      expect(availablePerLineDoc).toBeInstanceOf(D.Text)
+      expect(availablePerLineDoc).toHaveProperty("text", "80")
+      expect(unboundedDoc).toBeInstanceOf(D.Char)
+      expect(unboundedDoc).toHaveProperty("char", "a")
+    })
+
+    it("Nesting", () => {
+      const doc = new D.Nesting((l: number): Doc<never> => new D.Text(`${l}`, identity))
+      const reactedDoc = doc.react(4)
+
+      expect(doc).toBeInstanceOf(D.Nesting)
+      expect(doc.react).toBeDefined()
+      expect(reactedDoc).toBeInstanceOf(D.Text)
+      expect(reactedDoc).toHaveProperty("text", "4")
+    })
+
+    it("Annotated", () => {
+      const doc = new D.Annotated(1, new D.Char("a", identity))
+
+      expect(doc).toBeInstanceOf(D.Annotated)
+      expect(doc.annotation).toBe(1)
+      expect(doc.doc).toBeInstanceOf(D.Char)
+      expect(doc.doc).toHaveProperty("char", "a")
+    })
+  })
+
+  describe("constructors", () => {
+    it("fail", () => {
+      expect(D.fail).toBeInstanceOf(D.Fail)
+    })
+
+    it("empty", () => {
+      const doc = D.vsep([D.text("hello"), D.parens(D.empty), D.text("world")])
+      const actual = R.renderPrettyDefault(doc)
+      const expected = `
+hello
+()
+world`.trim()
+
+      expect(actual).toEqual(expected)
+    })
+
+    it("char", () => {
+      const doc = D.char("a")
+      const actual = R.renderPrettyDefault(doc)
+      const expected = "a"
+
+      expect(actual).toBe(expected)
+    })
+
+    it("text", () => {
+      const doc = D.text("foo")
+      const actual = R.renderPrettyDefault(doc)
+      const expected = "foo"
+
+      expect(actual).toBe(expected)
+    })
+
+    it("string", () => {
+      const doc = D.string("foo\nbar")
+      const actual = R.renderPrettyDefault(doc)
+      const expected = "foobar"
+
+      expect(actual).toBe(expected)
+    })
+
+    it("flatAlt", () => {
+      const open = D.flatAlt_(D.empty, D.text("{ "))
+      const close = D.flatAlt_(D.empty, D.text(" }"))
+      const separator = D.flatAlt_(D.empty, D.text("; "))
+
+      const prettyDo = <A>(xs: Array<Doc<A>>): Doc<A> =>
+        D.group(
+          D.hsep([D.text("do"), D.align(D.encloseSep_(xs, open, close, separator))])
+        )
+
+      const statements = [
+        D.text("name:_ <- getArgs"),
+        D.text('let greet = "Hello, " <> name"'),
+        D.text("putStrLn greet")
+      ]
+
+      expect(pipe(prettyDo(statements), R.renderPretty(80))).toBe(
+        `
+do { name:_ <- getArgs; let greet = "Hello, " <> name"; putStrLn greet }
+      `.trim()
       )
-    ).toEqual("hello\nworld\nI\nam\nalive")
+
+      expect(pipe(prettyDo(statements), R.renderPretty(10))).toBe(
+        `
+do name:_ <- getArgs
+   let greet = "Hello, " <> name"
+   putStrLn greet
+      `.trim()
+      )
+    })
+
+    it("union", () => {
+      const doc = D.union_(D.string("A long string of words"), D.char("b"))
+
+      expect(R.renderPrettyDefault(doc)).toBe("A long string of words")
+      expect(R.renderPretty(1)(doc)).toBe("b")
+    })
+
+    it("cat", () => {
+      const doc = D.cat_(D.char("a"), D.char("b"))
+      const actual = R.renderPrettyDefault(doc)
+      const expected = "ab"
+
+      expect(actual).toBe(expected)
+    })
+
+    it("line", () => {
+      const doc = D.hcat([D.text("lorem ipsum"), D.line, D.text("dolor sit amet")])
+
+      expect(R.renderPrettyDefault(doc)).toBe(
+        `
+lorem ipsum
+dolor sit amet`.trim()
+      )
+      expect(R.renderPrettyDefault(D.group(doc))).toBe("lorem ipsum dolor sit amet")
+    })
+
+    it("lineBreak", () => {
+      const doc = D.hcat([D.text("lorem ipsum"), D.lineBreak, D.text("dolor sit amet")])
+
+      expect(R.renderPrettyDefault(doc)).toBe(
+        `
+lorem ipsum
+dolor sit amet`.trim()
+      )
+      expect(R.renderPrettyDefault(D.group(doc))).toBe("lorem ipsumdolor sit amet")
+    })
+
+    it("softLine", () => {
+      const doc = D.hcat([D.text("lorem ipsum"), D.softLine, D.text("dolor sit amet")])
+
+      expect(pipe(doc, R.renderPretty(80))).toBe("lorem ipsum dolor sit amet")
+      expect(pipe(doc, R.renderPretty(10))).toBe(
+        `
+lorem ipsum
+dolor sit amet`.trim()
+      )
+    })
+
+    it("softLineBreak", () => {
+      const doc = D.hcat([D.text("ThisText"), D.softLineBreak, D.text("IsWayTooLong")])
+
+      expect(pipe(doc, R.renderPretty(80))).toBe("ThisTextIsWayTooLong")
+      expect(pipe(doc, R.renderPretty(10))).toBe(
+        `
+ThisText
+IsWayTooLong`.trim()
+      )
+    })
+
+    it("hardLine", () => {
+      const doc = D.hcat([D.text("lorem ipsum"), D.hardLine, D.text("dolor sit amet")])
+
+      expect(pipe(doc, R.renderPretty(1000))).toBe(
+        `
+lorem ipsum
+dolor sit amet`.trim()
+      )
+    })
+
+    it("nest", () => {
+      const doc = D.vsep([
+        D.nest_(D.vsep(D.words("lorem ipsum dolor")), 4),
+        D.text("sit"),
+        D.text("amet")
+      ])
+
+      expect(R.renderPrettyDefault(doc)).toBe(
+        `
+lorem
+    ipsum
+    dolor
+sit
+amet`.trim()
+      )
+    })
+
+    it("column", () => {
+      const prefix = D.hsep([
+        D.text("prefix"),
+        D.column((l) => D.text(`| <- column ${l}`))
+      ])
+      const doc = D.vsep(A.map_([0, 4, 8], (n) => D.indent_(prefix, n)))
+
+      expect(R.renderPrettyDefault(doc)).toBe(
+        `
+prefix | <- column 7
+    prefix | <- column 11
+        prefix | <- column 15`.trim()
+      )
+    })
+
+    it("nesting", () => {
+      const prefix = D.hsep([
+        D.text("prefix"),
+        D.nesting((l) => D.brackets(D.text(`Nested: ${l}`)))
+      ])
+      const doc = D.vsep(A.map_([0, 4, 8], (n) => D.indent_(prefix, n)))
+
+      expect(R.renderPrettyDefault(doc)).toBe(
+        `
+prefix [Nested: 0]
+    prefix [Nested: 4]
+        prefix [Nested: 8]`.trim()
+      )
+    })
+
+    it("withPageWidth", () => {
+      const prefix = D.hsep([
+        D.text("prefix"),
+        D.withPageWidth(
+          PW.match({
+            AvailablePerLine: (lw, rf) =>
+              D.brackets(D.text(`Width: ${lw}, Ribbon Fraction: ${rf}`)),
+            Unbounded: () => D.empty
+          })
+        )
+      ])
+      const doc = D.vsep(A.map_([0, 4, 8], (n) => D.indent_(prefix, n)))
+
+      expect(pipe(doc, R.renderPretty(32))).toBe(
+        `
+prefix [Width: 32, Ribbon Fraction: 1]
+    prefix [Width: 32, Ribbon Fraction: 1]
+        prefix [Width: 32, Ribbon Fraction: 1]`.trim()
+      )
+    })
+
+    it("annotate", () => {
+      const doc = D.annotate_(D.text("foo"), 1)
+
+      expect(R.renderPrettyDefault(doc)).toBe("foo")
+    })
+  })
+
+  describe("destructors", () => {
+    it("match", () => {
+      const match = D.match({
+        Fail: constant("Fail"),
+        Empty: constant("Empty"),
+        Char: constant("Char"),
+        Text: constant("Text"),
+        Line: constant("Line"),
+        FlatAlt: constant("FlatAlt"),
+        Cat: constant("Cat"),
+        Nest: constant("Nest"),
+        Union: constant("Union"),
+        Column: constant("Column"),
+        WithPageWidth: constant("WithPageWidth"),
+        Nesting: constant("Nesting"),
+        Annotated: constant("Annotated")
+      })
+
+      expect(match(D.fail)).toBe("Fail")
+      expect(match(D.empty)).toBe("Empty")
+      expect(match(D.char("a"))).toBe("Char")
+      expect(match(D.text("foo"))).toBe("Text")
+      expect(match(D.hardLine)).toBe("Line")
+      expect(match(D.flatAlt_(D.char("a"), D.char("b")))).toBe("FlatAlt")
+      expect(match(D.cat_(D.char("a"), D.char("b")))).toBe("Cat")
+      expect(match(D.nest_(D.char("a"), 4))).toBe("Nest")
+      expect(match(D.union_(D.char("a"), D.char("b")))).toBe("Union")
+      expect(match(D.column(() => D.char("a")))).toBe("Column")
+      expect(match(D.withPageWidth(() => D.char("a")))).toBe("WithPageWidth")
+      expect(match(D.nesting(() => D.char("a")))).toBe("Nesting")
+      expect(match(D.annotate_(D.char("a"), 1))).toBe("Annotated")
+    })
+  })
+
+  describe("operations", () => {
+    it("isFail", () => {
+      expect(D.isFail(D.fail)).toBeTruthy()
+      expect(D.isFail(D.char("a"))).toBeFalsy()
+    })
+
+    it("isEmpty", () => {
+      expect(D.isEmpty(D.empty)).toBeTruthy()
+      expect(D.isEmpty(D.char("a"))).toBeFalsy()
+    })
+
+    it("isChar", () => {
+      expect(D.isChar(D.char("a"))).toBeTruthy()
+      expect(D.isChar(D.text("foo"))).toBeFalsy()
+    })
+
+    it("isText", () => {
+      expect(D.isText(D.text("foo"))).toBeTruthy()
+      expect(D.isText(D.char("a"))).toBeFalsy()
+    })
+
+    it("isLine", () => {
+      expect(D.isLine(D.hardLine)).toBeTruthy()
+      expect(D.isLine(D.char("a"))).toBeFalsy()
+    })
+
+    it("isFlatAlt", () => {
+      expect(D.isFlatAlt(D.flatAlt_(D.char("a"), D.char("b")))).toBeTruthy()
+      expect(D.isFlatAlt(D.char("a"))).toBeFalsy()
+    })
+
+    it("isCat", () => {
+      expect(D.isCat(D.cat_(D.char("a"), D.char("b")))).toBeTruthy()
+      expect(D.isCat(D.char("a"))).toBeFalsy()
+    })
+
+    it("isNest", () => {
+      expect(D.isNest(D.nest_(D.char("a"), 4))).toBeTruthy()
+      expect(D.isNest(D.char("a"))).toBeFalsy()
+    })
+
+    it("isUnion", () => {
+      expect(D.isUnion(D.union_(D.char("a"), D.char("b")))).toBeTruthy()
+      expect(D.isUnion(D.char("a"))).toBeFalsy()
+    })
+
+    it("isColumn", () => {
+      expect(D.isColumn(D.column(() => D.char("a")))).toBeTruthy()
+      expect(D.isColumn(D.char("a"))).toBeFalsy()
+    })
+
+    it("isWithPageWidth", () => {
+      expect(D.isWithPageWidth(D.withPageWidth(() => D.char("a")))).toBeTruthy()
+      expect(D.isWithPageWidth(D.char("a"))).toBeFalsy()
+    })
+
+    it("isNesting", () => {
+      expect(D.isNesting(D.nesting(() => D.char("a")))).toBeTruthy()
+      expect(D.isNesting(D.char("a"))).toBeFalsy()
+    })
+
+    it("isAnnotated", () => {
+      expect(D.isAnnotated(D.annotate_(D.char("a"), 1))).toBeTruthy()
+      expect(D.isAnnotated(D.char("a"))).toBeFalsy()
+    })
   })
 })

--- a/packages/printer/test/doc.test.ts
+++ b/packages/printer/test/doc.test.ts
@@ -1,6 +1,6 @@
 import type { Array } from "@effect-ts/core/Array"
 import * as A from "@effect-ts/core/Array"
-import { constant, pipe } from "@effect-ts/system/Function"
+import { constant, flow, pipe } from "@effect-ts/system/Function"
 
 import type { Doc } from "../src/Core/Doc"
 import * as D from "../src/Core/Doc"
@@ -15,37 +15,31 @@ describe("Doc", () => {
 
     it("empty", () => {
       const doc = D.vsep([D.text("hello"), D.parens(D.empty), D.text("world")])
-      const actual = R.renderPrettyDefault(doc)
-      const expected = `
+
+      expect(R.renderPrettyDefault(doc)).toEqual(
+        `
 hello
 ()
 world`.trim()
-
-      expect(actual).toEqual(expected)
+      )
     })
 
     it("char", () => {
       const doc = D.char("a")
-      const actual = R.renderPrettyDefault(doc)
-      const expected = "a"
 
-      expect(actual).toBe(expected)
+      expect(R.renderPrettyDefault(doc)).toBe("a")
     })
 
     it("text", () => {
       const doc = D.text("foo")
-      const actual = R.renderPrettyDefault(doc)
-      const expected = "foo"
 
-      expect(actual).toBe(expected)
+      expect(R.renderPrettyDefault(doc)).toBe("foo")
     })
 
     it("string", () => {
       const doc = D.string("foo\nbar")
-      const actual = R.renderPrettyDefault(doc)
-      const expected = "foobar"
 
-      expect(actual).toBe(expected)
+      expect(R.renderPrettyDefault(doc)).toBe("foobar")
     })
 
     it("flatAlt", () => {
@@ -88,10 +82,8 @@ do name:_ <- getArgs
 
     it("cat", () => {
       const doc = D.cat_(D.char("a"), D.char("b"))
-      const actual = R.renderPrettyDefault(doc)
-      const expected = "ab"
 
-      expect(actual).toBe(expected)
+      expect(R.renderPrettyDefault(doc)).toBe("ab")
     })
 
     it("line", () => {
@@ -321,6 +313,459 @@ prefix [Width: 32, Ribbon Fraction: 1]
     it("isAnnotated", () => {
       expect(D.isAnnotated(D.annotate_(D.char("a"), 1))).toBeTruthy()
       expect(D.isAnnotated(D.char("a"))).toBeFalsy()
+    })
+
+    // TODO: figure out a way to test the `annotation` operations
+  })
+
+  describe("concatenation combinators", () => {
+    it("concatWith", () => {
+      const doc = D.concatWith_([D.char("a"), D.char("b")], D.appendWithSpace_)
+
+      expect(R.renderPrettyDefault(doc)).toBe("a b")
+    })
+
+    it("appendWithSpace", () => {
+      const doc = D.appendWithSpace_(D.char("a"), D.char("b"))
+
+      expect(R.renderPrettyDefault(doc)).toBe("a b")
+    })
+
+    it("appendWithLine", () => {
+      const doc = D.appendWithLine_(D.char("a"), D.char("b"))
+
+      expect(R.renderPrettyDefault(doc)).toBe("a\nb")
+    })
+
+    it("appendWithLineBreak", () => {
+      const doc = D.appendWithLineBreak_(D.char("a"), D.char("b"))
+
+      expect(R.renderPrettyDefault(doc)).toBe("a\nb")
+      expect(R.renderPrettyDefault(D.group(doc))).toBe("ab")
+    })
+
+    it("appendWithSoftLine", () => {
+      const doc = D.appendWithSoftLine_(D.char("a"), D.char("b"))
+
+      expect(R.renderPrettyDefault(doc)).toBe("a b")
+      expect(pipe(doc, R.renderPretty(1))).toBe("a\nb")
+    })
+
+    it("appendWithSoftLineBreak", () => {
+      const doc = D.appendWithSoftLineBreak_(D.char("a"), D.char("b"))
+
+      expect(R.renderPrettyDefault(doc)).toBe("ab")
+      expect(pipe(doc, R.renderPretty(1))).toBe("a\nb")
+    })
+  })
+
+  describe("alternative combinators", () => {
+    describe("group", () => {
+      it("should ensure that the `left` document is less wide than the `right`", () => {
+        const doc = D.group(D.flatAlt_(D.text("even wider"), D.text("too wide")))
+
+        // If the `right` document does not fit the page, the algorithm falls
+        // back to an even wider layout
+        expect(pipe(doc, R.renderPretty(7))).toBe("even wider")
+      })
+
+      it("should flatten the right document", () => {
+        const doc = D.group(
+          D.flatAlt_(D.char("x"), D.hcat([D.char("y"), D.line, D.char("y")]))
+        )
+
+        expect(R.renderPrettyDefault(doc)).toBe("y y")
+      })
+
+      it("should never render an unflattenable `right` document", () => {
+        const doc = D.group(
+          D.flatAlt_(D.char("x"), D.hcat([D.char("y"), D.hardLine, D.char("y")]))
+        )
+
+        expect(R.renderPrettyDefault(doc)).toBe("x")
+      })
+    })
+  })
+
+  describe("sep combinators", () => {
+    it("hsep", () => {
+      const doc = D.hsep(D.words("lorem ipsum dolor sit amet"))
+
+      expect(R.renderPrettyDefault(doc)).toBe("lorem ipsum dolor sit amet")
+      expect(pipe(doc, R.renderPretty(5))).toBe("lorem ipsum dolor sit amet")
+    })
+
+    it("vsep", () => {
+      const doc = D.hsep([D.text("prefix"), D.vsep(D.words("text to lay out"))])
+
+      expect(R.renderPrettyDefault(doc)).toBe(
+        `
+prefix text
+to
+lay
+out`.trim()
+      )
+    })
+
+    it("fillSep", () => {
+      const doc = D.fillSep(D.words("lorem ipsum dolor sit amet"))
+
+      expect(R.renderPrettyDefault(doc)).toBe("lorem ipsum dolor sit amet")
+      expect(pipe(doc, R.renderPretty(10))).toBe(
+        `
+lorem
+ipsum
+dolor sit
+amet`.trim()
+      )
+    })
+
+    it("sep", () => {
+      const doc = D.hsep([D.text("prefix"), D.seps(D.words("text to lay out"))])
+
+      expect(R.renderPrettyDefault(doc)).toBe("prefix text to lay out")
+      expect(pipe(doc, R.renderPretty(20))).toBe(
+        `
+prefix text
+to
+lay
+out`.trim()
+      )
+    })
+  })
+
+  describe("cat combinators", () => {
+    it("hcat", () => {
+      const doc = D.hcat(D.words("lorem ipsum dolor sit amet"))
+
+      expect(R.renderPrettyDefault(doc)).toBe("loremipsumdolorsitamet")
+    })
+
+    it("vcat", () => {
+      const doc = D.vcat(D.words("lorem ipsum dolor sit amet"))
+
+      expect(R.renderPrettyDefault(doc)).toBe(
+        `
+lorem
+ipsum
+dolor
+sit
+amet`.trim()
+      )
+    })
+
+    it("fillCat", () => {
+      const doc = D.fillCat(D.words("lorem ipsum dolor sit amet"))
+
+      expect(R.renderPrettyDefault(doc)).toBe("loremipsumdolorsitamet")
+      expect(pipe(doc, R.renderPretty(10))).toBe(
+        `
+loremipsum
+dolorsit
+amet`.trim()
+      )
+    })
+
+    it("cats", () => {
+      const doc = D.hsep([D.text("Docs:"), D.cats(D.words("lorem ipsum dolor"))])
+
+      expect(R.renderPrettyDefault(doc)).toBe("Docs: loremipsumdolor")
+      expect(pipe(doc, R.renderPretty(10))).toBe(
+        `
+Docs: lorem
+ipsum
+dolor`.trim()
+      )
+    })
+  })
+
+  describe("filler combinators", () => {
+    it("fill", () => {
+      type Signature = [name: string, type: string]
+
+      const signatures: Array<Signature> = [
+        ["empty", "Doc"],
+        ["nest", "Int -> Doc -> Doc"],
+        ["fillSep", "[Doc] -> Doc"]
+      ]
+
+      const prettySignature = <A>([name, type]: Signature): Doc<A> =>
+        D.hsep([D.fill_(D.text(name), 5), D.text("::"), D.text(type)])
+
+      const doc = D.hsep([
+        D.text("let"),
+        D.align(D.vcat(A.map_(signatures, prettySignature)))
+      ])
+
+      expect(R.renderPrettyDefault(doc)).toBe(
+        `
+let empty :: Doc
+    nest  :: Int -> Doc -> Doc
+    fillSep :: [Doc] -> Doc`.trim()
+      )
+    })
+
+    it("fillBreak", () => {
+      type Signature = [name: string, type: string]
+
+      const signatures: Array<Signature> = [
+        ["empty", "Doc"],
+        ["nest", "Int -> Doc -> Doc"],
+        ["fillSep", "[Doc] -> Doc"]
+      ]
+
+      const prettySignature = <A>([name, type]: Signature): Doc<A> =>
+        D.hsep([D.fillBreak_(D.text(name), 5), D.text("::"), D.text(type)])
+
+      const doc = D.hsep([
+        D.text("let"),
+        D.align(D.vcat(A.map_(signatures, prettySignature)))
+      ])
+
+      expect(R.renderPrettyDefault(doc)).toBe(
+        `
+let empty :: Doc
+    nest  :: Int -> Doc -> Doc
+    fillSep
+          :: [Doc] -> Doc`.trim()
+      )
+    })
+  })
+
+  describe("alignment combinators", () => {
+    it("align", () => {
+      const doc = D.hsep([
+        D.text("lorem"),
+        D.align(D.vsep([D.text("ipsum"), D.text("dolor")]))
+      ])
+
+      expect(R.renderPrettyDefault(doc)).toBe(
+        `
+lorem ipsum
+      dolor`.trim()
+      )
+    })
+
+    it("hang", () => {
+      const doc = D.hsep([
+        D.text("prefix"),
+        D.hang_(D.reflow("Indenting these words with hang"), 4)
+      ])
+
+      expect(pipe(doc, R.renderPretty(24))).toBe(
+        `
+prefix Indenting these
+           words with
+           hang`.trim()
+      )
+    })
+
+    it("indent", () => {
+      const doc = D.hcat([
+        D.text("prefix"),
+        D.indent_(D.reflow("The indent function indents these words!"), 4)
+      ])
+
+      expect(pipe(doc, R.renderPretty(24))).toBe(
+        `
+prefix    The indent
+          function
+          indents these
+          words!`.trim()
+      )
+    })
+
+    it("encloseSep", () => {
+      const doc = D.hsep([
+        D.text("list"),
+        D.align(
+          pipe(
+            A.map_(["1", "20", "300", "4000"], (n) =>
+              n.length === 1 ? D.char(n) : D.text(n)
+            ),
+            D.encloseSep(D.lbracket, D.rbracket, D.comma)
+          )
+        )
+      ])
+
+      expect(R.renderPrettyDefault(doc)).toBe("list [1,20,300,4000]")
+
+      expect(pipe(doc, R.renderPretty(10))).toBe(
+        `
+list [1
+     ,20
+     ,300
+     ,4000]`.trim()
+      )
+    })
+
+    it("list", () => {
+      const doc = D.list(
+        A.map_(["1", "20", "300", "4000"], (n) =>
+          n.length === 1 ? D.char(n) : D.text(n)
+        )
+      )
+
+      expect(R.renderPrettyDefault(doc)).toBe("[1, 20, 300, 4000]")
+    })
+
+    it("tupled", () => {
+      const doc = D.tupled(
+        A.map_(["1", "20", "300", "4000"], (n) =>
+          n.length === 1 ? D.char(n) : D.text(n)
+        )
+      )
+
+      expect(R.renderPrettyDefault(doc)).toBe("(1, 20, 300, 4000)")
+    })
+  })
+
+  describe("reactive/conditional combinators", () => {
+    const annotate: <A>(doc: Doc<A>) => Doc<A> = flow(
+      D.brackets,
+      D.width((w) => D.text(` <- width: ${w}`))
+    )
+
+    const docs = [
+      D.text("---"),
+      D.text("------"),
+      D.indent_(D.text("---"), 3),
+      D.vsep([D.text("---"), D.indent_(D.text("---"), 4)])
+    ]
+
+    const doc = D.align(D.vsep(A.map_(docs, annotate)))
+
+    expect(R.renderPrettyDefault(doc)).toBe(
+      `
+[---] <- width: 5
+[------] <- width: 8
+[   ---] <- width: 8
+[---
+    ---] <- width: 8`.trim()
+    )
+  })
+
+  describe("general combinators", () => {
+    it("punctuate", () => {
+      const docs = D.punctuate_(D.words("lorem ipsum dolor sit amet"), D.comma)
+
+      expect(R.renderPrettyDefault(D.hsep(docs))).toBe("lorem, ipsum, dolor, sit, amet")
+      // lorem, ipsum, dolor, sit, amet
+
+      // The separators are put at the end of the entries, which can be better
+      // visualzied if the documents are rendered vertically
+      expect(R.renderPrettyDefault(D.vsep(docs))).toBe(
+        `
+lorem,
+ipsum,
+dolor,
+sit,
+amet`.trim()
+      )
+    })
+
+    it("enclose", () => {
+      const doc = pipe(D.char("-"), D.enclose(D.char("A"), D.char("Z")))
+
+      expect(R.renderPrettyDefault(doc)).toBe("A-Z")
+    })
+
+    it("surround", () => {
+      const doc = pipe(
+        D.words("@effect-ts printer Core Doc"),
+        D.concatWith(D.surround(D.slash))
+      )
+
+      expect(R.renderPrettyDefault(doc)).toBe("@effect-ts/printer/Core/Doc")
+    })
+
+    it("parens", () => {
+      const doc = D.parens(D.char("a"))
+
+      expect(R.renderPrettyDefault(doc)).toBe("(a)")
+    })
+
+    it("angles", () => {
+      const doc = D.angles(D.char("a"))
+
+      expect(R.renderPrettyDefault(doc)).toBe("<a>")
+    })
+
+    it("brackets", () => {
+      const doc = D.brackets(D.char("a"))
+
+      expect(R.renderPrettyDefault(doc)).toBe("[a]")
+    })
+
+    it("braces", () => {
+      const doc = D.braces(D.char("a"))
+
+      expect(R.renderPrettyDefault(doc)).toBe("{a}")
+    })
+
+    it("squotes", () => {
+      const doc = D.squotes(D.char("a"))
+
+      expect(R.renderPrettyDefault(doc)).toBe("'a'")
+    })
+
+    it("dquotes", () => {
+      const doc = D.dquotes(D.char("a"))
+
+      expect(R.renderPrettyDefault(doc)).toBe('"a"')
+    })
+
+    it("spaces", () => {
+      const doc = D.brackets(D.dquotes(D.spaces(5)))
+
+      expect(R.renderPrettyDefault(doc)).toBe('["     "]')
+    })
+
+    it("words", () => {
+      const doc = D.tupled(D.words("lorem ipsum dolor"))
+
+      expect(R.renderPrettyDefault(doc)).toBe("(lorem, ipsum, dolor)")
+    })
+
+    it("reflow", () => {
+      const doc = D.reflow(
+        "Lorem ipsum dolor sit amet, consectetur adipisicing elit, " +
+          "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+      )
+
+      expect(pipe(doc, R.renderPretty(32))).toBe(
+        `
+Lorem ipsum dolor sit amet,
+consectetur adipisicing elit,
+sed do eiusmod tempor incididunt
+ut labore et dolore magna
+aliqua.`.trim()
+      )
+    })
+  })
+
+  describe("instances", () => {
+    it("Associative", () => {
+      const A = D.getAssociative<never>()
+      const doc = A.combine(D.text("hello"), D.text("world"))
+
+      expect(R.renderPrettyDefault(doc)).toBe("helloworld")
+    })
+
+    it("Identity", () => {
+      const I = D.getIdentity<never>()
+      const doc = I.combine(
+        D.text("hello"),
+        I.combine(D.parens(I.identity), D.text("world"))
+      )
+
+      expect(R.renderPrettyDefault(doc)).toEqual("hello()world")
+    })
+  })
+
+  describe("utils", () => {
+    it("textSpaces", () => {
+      expect(D.textSpaces(4)).toBe("    ")
     })
   })
 })

--- a/packages/printer/test/doc.test.ts
+++ b/packages/printer/test/doc.test.ts
@@ -1,6 +1,6 @@
 import type { Array } from "@effect-ts/core/Array"
 import * as A from "@effect-ts/core/Array"
-import { constant, identity, pipe } from "@effect-ts/system/Function"
+import { constant, pipe } from "@effect-ts/system/Function"
 
 import type { Doc } from "../src/Core/Doc"
 import * as D from "../src/Core/Doc"
@@ -8,116 +8,6 @@ import * as PW from "../src/Core/PageWidth"
 import * as R from "../src/Core/Render"
 
 describe("Doc", () => {
-  describe("definition", () => {
-    it("Fail", () => {
-      const doc = new D.Fail(identity)
-
-      expect(doc).toBeInstanceOf(D.Fail)
-      expect(doc.id).toBeDefined()
-    })
-
-    it("Char", () => {
-      const doc = new D.Char("a", identity)
-
-      expect(doc).toBeInstanceOf(D.Char)
-      expect(doc.id).toBeDefined()
-      expect(doc.char).toBe("a")
-    })
-
-    it("Text", () => {
-      const doc = new D.Text("foo", identity)
-
-      expect(doc).toBeInstanceOf(D.Text)
-      expect(doc.id).toBeDefined()
-      expect(doc.text).toBe("foo")
-    })
-
-    it("FlatAlt", () => {
-      const doc = new D.FlatAlt(new D.Char("a", identity), new D.Char("b", identity))
-
-      expect(doc).toBeInstanceOf(D.FlatAlt)
-      expect(doc.left).toBeInstanceOf(D.Char)
-      expect(doc.left).toHaveProperty("char", "a")
-      expect(doc.right).toBeInstanceOf(D.Char)
-      expect(doc.right).toHaveProperty("char", "b")
-    })
-
-    it("Cat", () => {
-      const doc = new D.Cat(new D.Char("a", identity), new D.Char("b", identity))
-
-      expect(doc).toBeInstanceOf(D.Cat)
-      expect(doc.left).toBeInstanceOf(D.Char)
-      expect(doc.left).toHaveProperty("char", "a")
-      expect(doc.right).toBeInstanceOf(D.Char)
-      expect(doc.right).toHaveProperty("char", "b")
-    })
-
-    it("Nest", () => {
-      const doc = new D.Nest(4, new D.Char("a", identity))
-
-      expect(doc).toBeInstanceOf(D.Nest)
-      expect(doc.doc).toBeInstanceOf(D.Char)
-      expect(doc.doc).toHaveProperty("char", "a")
-      expect(doc.indent).toBe(4)
-    })
-
-    it("Union", () => {
-      const doc = new D.Union(new D.Char("a", identity), new D.Char("b", identity))
-
-      expect(doc).toBeInstanceOf(D.Union)
-      expect(doc.left).toBeInstanceOf(D.Char)
-      expect(doc.left).toHaveProperty("char", "a")
-      expect(doc.right).toBeInstanceOf(D.Char)
-      expect(doc.right).toHaveProperty("char", "b")
-    })
-
-    it("Column", () => {
-      const doc = new D.Column((pos) => new D.Text(`${pos}`, identity))
-      const reactedDoc = doc.react(4)
-
-      expect(doc).toBeInstanceOf(D.Column)
-      expect(doc.react).toBeDefined()
-      expect(reactedDoc).toBeInstanceOf(D.Text)
-      expect(reactedDoc).toHaveProperty("text", "4")
-    })
-
-    it("WithPageWidth", () => {
-      const react = (w: PW.PageWidth): D.Doc<never> =>
-        w._tag === "AvailablePerLine"
-          ? new D.Text(`${w.lineWidth}`, identity)
-          : new D.Char("a", identity)
-      const doc = new D.WithPageWidth(react)
-      const availablePerLineDoc = doc.react(PW.availablePerLine(80, 1))
-      const unboundedDoc = doc.react(PW.unbounded)
-
-      expect(doc).toBeInstanceOf(D.WithPageWidth)
-      expect(doc.react).toBeDefined()
-      expect(availablePerLineDoc).toBeInstanceOf(D.Text)
-      expect(availablePerLineDoc).toHaveProperty("text", "80")
-      expect(unboundedDoc).toBeInstanceOf(D.Char)
-      expect(unboundedDoc).toHaveProperty("char", "a")
-    })
-
-    it("Nesting", () => {
-      const doc = new D.Nesting((l: number): Doc<never> => new D.Text(`${l}`, identity))
-      const reactedDoc = doc.react(4)
-
-      expect(doc).toBeInstanceOf(D.Nesting)
-      expect(doc.react).toBeDefined()
-      expect(reactedDoc).toBeInstanceOf(D.Text)
-      expect(reactedDoc).toHaveProperty("text", "4")
-    })
-
-    it("Annotated", () => {
-      const doc = new D.Annotated(1, new D.Char("a", identity))
-
-      expect(doc).toBeInstanceOf(D.Annotated)
-      expect(doc.annotation).toBe(1)
-      expect(doc.doc).toBeInstanceOf(D.Char)
-      expect(doc.doc).toHaveProperty("char", "a")
-    })
-  })
-
   describe("constructors", () => {
     it("fail", () => {
       expect(D.fail).toBeInstanceOf(D.Fail)

--- a/packages/printer/test/docStream.test.ts
+++ b/packages/printer/test/docStream.test.ts
@@ -1,0 +1,64 @@
+import * as S from "../src/Core/DocStream"
+
+describe("DocStream", () => {
+  describe("destructors", () => {
+    it("match", () => {
+      const match = S.match({
+        FailedStream: () => "FailedStream",
+        EmptyStream: () => "EmptyStream",
+        CharStream: () => "CharStream",
+        TextStream: () => "TextStream",
+        LineStream: () => "LineStream",
+        PushAnnotationStream: () => "PushAnnotationStream",
+        PopAnnotationStream: () => "PopAnnotationStream"
+      })
+
+      expect(match(S.failed)).toBe("FailedStream")
+      expect(match(S.empty)).toBe("EmptyStream")
+      expect(match(S.char_(S.empty, "a"))).toBe("CharStream")
+      expect(match(S.text_(S.empty, "foo"))).toBe("TextStream")
+      expect(match(S.line_(S.empty, 4))).toBe("LineStream")
+      expect(match(S.pushAnnotation_(S.empty, 1))).toBe("PushAnnotationStream")
+      expect(match(S.popAnnotation(S.empty))).toBe("PopAnnotationStream")
+    })
+  })
+
+  describe("operations", () => {
+    it("isFailedStream", () => {
+      expect(S.isFailedStream(S.failed)).toBeTruthy()
+      expect(S.isFailedStream(S.empty)).toBeFalsy()
+    })
+
+    it("isEmptyStream", () => {
+      expect(S.isEmptyStream(S.empty)).toBeTruthy()
+      expect(S.isEmptyStream(S.failed)).toBeFalsy()
+    })
+
+    it("isCharStream", () => {
+      expect(S.isCharStream(S.char_(S.empty, "a"))).toBeTruthy()
+      expect(S.isCharStream(S.empty)).toBeFalsy()
+    })
+
+    it("isTextStream", () => {
+      expect(S.isTextStream(S.text_(S.empty, "foo"))).toBeTruthy()
+      expect(S.isTextStream(S.empty)).toBeFalsy()
+    })
+
+    it("isLineStream", () => {
+      expect(S.isLineStream(S.line_(S.empty, 4))).toBeTruthy()
+      expect(S.isLineStream(S.empty)).toBeFalsy()
+    })
+
+    it("isPushAnnotationStream", () => {
+      expect(S.isPushAnnotationStream(S.pushAnnotation_(S.empty, 1))).toBeTruthy()
+      expect(S.isPushAnnotationStream(S.empty)).toBeFalsy()
+    })
+
+    it("isPopAnnotationStream", () => {
+      expect(S.isPopAnnotationStream(S.popAnnotation(S.empty))).toBeTruthy()
+      expect(S.isPopAnnotationStream(S.empty)).toBeFalsy()
+    })
+  })
+
+  // TODO: figure out a way to test the `annotation` operations
+})

--- a/packages/printer/test/flatten.test.ts
+++ b/packages/printer/test/flatten.test.ts
@@ -1,0 +1,56 @@
+import { identity } from "@effect-ts/core/Function"
+
+import * as F from "../src/Core/Flatten"
+
+describe("Flatten", () => {
+  describe("constructors", () => {
+    it("flattened", () => {
+      expect(F.flattened(1)).toMatchObject({ _tag: "Flattened", value: 1 })
+    })
+
+    it("alreadyFlat", () => {
+      expect(F.alreadyFlat).toMatchObject({ _tag: "AlreadyFlat" })
+    })
+
+    it("neverFlat", () => {
+      expect(F.neverFlat).toMatchObject({ _tag: "NeverFlat" })
+    })
+  })
+
+  describe("destructors", () => {
+    it("match", () => {
+      const match = F.match({
+        Flattened: () => "Flattened",
+        AlreadyFlat: () => "AlreadyFlat",
+        NeverFlat: () => "NeverFlat"
+      })
+
+      expect(match(F.flattened(1))).toBe("Flattened")
+      expect(match(F.alreadyFlat)).toBe("AlreadyFlat")
+      expect(match(F.neverFlat)).toBe("NeverFlat")
+    })
+  })
+
+  describe("operations", () => {
+    it("isFlattened", () => {
+      expect(F.isFlattened(F.flattened(1))).toBeTruthy()
+      expect(F.isFlattened(F.neverFlat)).toBeFalsy()
+    })
+
+    it("isAlreadyFlat", () => {
+      expect(F.isAlreadyFlat(F.alreadyFlat)).toBeTruthy()
+      expect(F.isAlreadyFlat(F.neverFlat)).toBeFalsy()
+    })
+
+    it("isNeverFlat", () => {
+      expect(F.isNeverFlat(F.neverFlat)).toBeTruthy()
+      expect(F.isNeverFlat(F.alreadyFlat)).toBeFalsy()
+    })
+
+    it("map", () => {
+      expect(F.map_(F.flattened(1), (n) => n + 1)).toMatchObject(F.flattened(2))
+      expect(F.map_(F.alreadyFlat, identity)).toMatchObject(F.alreadyFlat)
+      expect(F.map_(F.neverFlat, identity)).toMatchObject(F.neverFlat)
+    })
+  })
+})

--- a/packages/printer/test/layout.test.ts
+++ b/packages/printer/test/layout.test.ts
@@ -1,0 +1,110 @@
+import * as A from "@effect-ts/core/Array"
+import { flow, pipe } from "@effect-ts/core/Function"
+import * as I from "@effect-ts/core/Identity"
+
+import type { Doc } from "../src/Core/Doc"
+import * as D from "../src/Core/Doc"
+import type { Layout, LayoutOptions } from "../src/Core/Layout"
+import * as L from "../src/Core/Layout"
+import type { PageWidth } from "../src/Core/PageWidth"
+import * as PW from "../src/Core/PageWidth"
+import * as R from "../src/Core/Render"
+
+describe("Layout", () => {
+  describe("constructors", () => {
+    it("defaultLayoutOptions", () => {
+      expect(L.defaultLayoutOptions).toMatchObject({
+        pageWidth: { _tag: "AvailablePerLine", lineWidth: 80, ribbonFraction: 1 }
+      })
+    })
+  })
+
+  describe("destructors", () => {
+    it("match", () => {
+      const match = L.match({
+        Nil: () => "Nil",
+        Cons: () => "Cons",
+        UndoAnnotation: () => "UndoAnnotation"
+      })
+
+      expect(match(L.nil)).toBe("Nil")
+      expect(match(L.cons(4, D.empty, L.nil))).toBe("Cons")
+      expect(match(L.undoAnnotation(L.nil))).toBe("UndoAnnotation")
+    })
+  })
+
+  describe("layout algorithms", () => {
+    const fun = <A>(doc: Doc<A>): Doc<A> =>
+      D.hcat([D.hang_(D.hcat([D.text("fun("), D.softLineBreak, doc]), 2), D.text(")")])
+
+    const funs = flow(fun, fun, fun, fun, fun)
+
+    const doc = funs(D.align(D.list(D.words("abcdef ghijklm"))))
+
+    const pageWidth: PageWidth = PW.availablePerLine(26, 1)
+
+    const layoutOptions: LayoutOptions = L.layoutOptions(pageWidth)
+
+    const dashes = D.text(pipe(A.replicate_(26 - 2, "-"), I.fold(I.string)))
+
+    const hr = D.hcat([D.vbar, dashes, D.vbar])
+
+    const render = <A>(doc: Doc<A>) => (
+      layoutAlgorithm: (doc: Doc<A>) => Layout<A>
+    ): string => pipe(layoutOptions, layoutAlgorithm(D.vsep([hr, doc, hr])), R.render)
+
+    it("unbounded", () => {
+      expect(pipe(L.unbounded(D.vsep([hr, doc, hr])), R.render)).toBe(
+        `
+|------------------------|
+fun(fun(fun(fun(fun([abcdef, ghijklm])))))
+|------------------------|
+      `.trim()
+      )
+    })
+
+    it("pretty", () => {
+      expect(pipe(L.pretty, render(doc))).toBe(
+        `
+|------------------------|
+fun(fun(fun(fun(fun(
+                  [ abcdef
+                  , ghijklm ])))))
+|------------------------|
+        `.trim()
+      )
+    })
+
+    it("smart", () => {
+      expect(pipe(L.smart, render(doc))).toBe(
+        `
+|------------------------|
+fun(
+  fun(
+    fun(
+      fun(
+        fun(
+          [ abcdef
+          , ghijklm ])))))
+|------------------------|
+        `.trim()
+      )
+    })
+
+    it("compact", () => {
+      expect(pipe(L.compact(D.vsep([hr, doc, hr])), R.render)).toBe(
+        `
+|------------------------|
+fun(
+fun(
+fun(
+fun(
+fun(
+[ abcdef
+, ghijklm ])))))
+|------------------------|
+      `.trim()
+      )
+    })
+  })
+})

--- a/packages/printer/test/optimize.test.ts
+++ b/packages/printer/test/optimize.test.ts
@@ -1,0 +1,40 @@
+import * as Eq from "@effect-ts/core/Equal"
+import * as fc from "fast-check"
+
+import * as D from "../src/Core/Doc"
+import * as O from "../src/Core/Optimize"
+import * as R from "../src/Core/Render"
+import { arbDoc } from "./test-utils"
+
+const arbFusionDepth: fc.Arbitrary<O.FusionDepth> = fc.oneof(
+  fc.constant(O.Shallow),
+  fc.constant(O.Deep)
+)
+
+describe("Optimize", () => {
+  it("should optimize fused documents", () => {
+    const unfused = D.hcatT(D.char("a"), D.char("b"), D.char("c"), D.char("d"))
+    const fused = O.optimize(unfused)(O.Deep)
+
+    // Unfused document will have individual documents for each character
+    expect(unfused).toHaveProperty(["left", "left", "left", "char"], "a")
+    expect(unfused).toHaveProperty(["left", "left", "right", "char"], "b")
+    expect(unfused).toHaveProperty(["left", "right", "char"], "c")
+    expect(unfused).toHaveProperty(["right", "char"], "d")
+
+    // Fused document will result in a single `Cat` document with two branches
+    // containing the concatenated characters in each branch of the previous
+    // unfused document
+    expect(fused).toHaveProperty("text", "abcd")
+  })
+
+  it("should render fused and unfused documents identically", () => {
+    fc.assert(
+      fc.property(arbDoc, arbFusionDepth, (doc, depth) => {
+        const fused = R.renderPrettyDefault(O.optimize(doc)(depth))
+        const unfused = R.renderPrettyDefault(doc)
+        return Eq.string.equals(fused, unfused)
+      })
+    )
+  })
+})

--- a/packages/printer/test/pageWidth.test.ts
+++ b/packages/printer/test/pageWidth.test.ts
@@ -1,0 +1,27 @@
+import * as PW from "../src/Core/PageWidth"
+
+describe("PageWidth", () => {
+  describe("constructors", () => {
+    it("availablePerLine", () => {
+      expect(PW.availablePerLine(80, 1)).toMatchObject({
+        _tag: "AvailablePerLine",
+        lineWidth: 80,
+        ribbonFraction: 1
+      })
+    })
+
+    it("unbounded", () => {
+      expect(PW.unbounded).toMatchObject({ _tag: "Unbounded" })
+    })
+
+    it("defaultPageWidth", () => {
+      expect(PW.defaultPageWidth).toMatchObject(PW.availablePerLine(80, 1))
+    })
+  })
+
+  describe("operations", () => {
+    it("remainingWidth", () => {
+      expect(PW.remainingWidth(80, 1, 4, 40)).toBe(40)
+    })
+  })
+})

--- a/packages/printer/test/render.test.ts
+++ b/packages/printer/test/render.test.ts
@@ -1,0 +1,110 @@
+import * as A from "@effect-ts/core/Array"
+import { flow, pipe } from "@effect-ts/core/Function"
+import * as I from "@effect-ts/core/Identity"
+
+import type { Doc } from "../src/Core/Doc"
+import * as D from "../src/Core/Doc"
+import * as R from "../src/Core/Render"
+
+const fun = <A>(doc: Doc<A>): Doc<A> =>
+  D.hcat([D.hang_(D.hcat([D.text("fun("), D.softLineBreak, doc]), 2), D.text(")")])
+
+const funs = flow(fun, fun, fun, fun, fun)
+
+const doc = funs(D.align(D.list(D.words("abcdef ghijklm"))))
+
+const dashes = D.text(pipe(A.replicate_(26 - 2, "-"), I.fold(I.string)))
+
+const hr = D.hcat([D.vbar, dashes, D.vbar])
+
+const page = D.vsep([hr, doc, hr])
+
+describe("Render", () => {
+  describe("rendering algorithms", () => {
+    it("renderPretty", () => {
+      expect(R.renderPretty_(page, 14, 1)).toBe(
+        `
+|------------------------|
+fun(fun(fun(
+          fun(
+            fun(
+              [ abcdef
+              , ghijklm ])))))
+|------------------------|
+        `.trim()
+      )
+    })
+
+    it("renderPrettyDefault", () => {
+      expect(R.renderPrettyDefault(page)).toBe(
+        `
+|------------------------|
+fun(fun(fun(fun(fun([abcdef, ghijklm])))))
+|------------------------|
+        `.trim()
+      )
+    })
+
+    it("renderPrettyUnbounded", () => {
+      expect(R.renderPrettyUnbounded(page)).toBe(
+        `
+|------------------------|
+fun(fun(fun(fun(fun([abcdef, ghijklm])))))
+|------------------------|
+      `.trim()
+      )
+    })
+
+    it("renderSmart", () => {
+      expect(R.renderSmart_(page, 14, 1)).toBe(
+        `
+|------------------------|
+fun(
+  fun(
+    fun(
+      fun(
+        fun(
+          [ abcdef
+          , ghijklm ])))))
+|------------------------|
+      `.trim()
+      )
+    })
+
+    it("renderSmartDefault", () => {
+      expect(R.renderSmartDefault(page)).toBe(
+        `
+|------------------------|
+fun(fun(fun(fun(fun([abcdef, ghijklm])))))
+|------------------------|
+      `.trim()
+      )
+    })
+
+    it("renderSmartUnbounded", () => {
+      expect(R.renderSmartDefault(page)).toBe(
+        `
+|------------------------|
+fun(fun(fun(fun(fun([abcdef, ghijklm])))))
+|------------------------|
+      `.trim()
+      )
+    })
+
+    it("renderCompact", () => {
+      expect(R.renderCompact(page)).toBe(
+        `
+|------------------------|
+fun(
+fun(
+fun(
+fun(
+fun(
+[ abcdef
+, ghijklm ])))))
+|------------------------|
+      `.trim()
+      )
+    })
+  })
+})

--- a/packages/printer/test/test-utils.ts
+++ b/packages/printer/test/test-utils.ts
@@ -1,0 +1,59 @@
+import { constant } from "@effect-ts/core/Function"
+import * as fc from "fast-check"
+
+import * as D from "../src/Core/Doc"
+
+export const arbEmpty: fc.Arbitrary<D.Doc<number>> = fc.constant(D.empty)
+
+export const arbChar: fc.Arbitrary<D.Doc<number>> = fc.char().map(D.char)
+
+export const arbText: fc.Arbitrary<D.Doc<number>> = fc.string().map(D.text)
+
+export const arbLine: fc.Arbitrary<D.Doc<number>> = fc.constant(D.hardLine)
+
+export const arbFlatAlt: fc.Arbitrary<D.Doc<number>> = fc
+  .tuple(fc.oneof(arbChar, arbText), fc.oneof(arbChar, arbText))
+  .map(([d1, d2]) => D.flatAlt_(d1, d2))
+
+export const arbCat: fc.Arbitrary<D.Doc<number>> = fc
+  .tuple(fc.oneof(arbChar, arbText), fc.oneof(arbChar, arbText))
+  .map(([d1, d2]) => D.cat_(d1, d2))
+
+export const arbNest: fc.Arbitrary<D.Doc<number>> = fc
+  .tuple(fc.oneof(arbChar, arbText), fc.integer())
+  .map(([d, i]) => D.nest_(d, i))
+
+export const arbUnion: fc.Arbitrary<D.Doc<number>> = fc
+  .tuple(fc.oneof(arbChar, arbText), fc.oneof(arbChar, arbText))
+  .map(([d1, d2]) => D.union_(d1, d2))
+
+export const arbColumn: fc.Arbitrary<D.Doc<number>> = fc
+  .oneof(arbChar, arbText)
+  .map((d) => D.column(constant(d)))
+
+export const arbWithPageWidth: fc.Arbitrary<D.Doc<number>> = fc
+  .oneof(arbChar, arbText)
+  .map((d) => D.withPageWidth(constant(d)))
+
+export const arbNesting: fc.Arbitrary<D.Doc<number>> = fc
+  .oneof(arbChar, arbText)
+  .map((d) => D.nesting(constant(d)))
+
+export const arbAnnotated: fc.Arbitrary<D.Doc<number>> = fc
+  .tuple(fc.oneof(arbChar, arbText), fc.integer())
+  .map(([d, n]) => D.annotate_(d, n))
+
+export const arbDoc: fc.Arbitrary<D.Doc<number>> = fc.oneof(
+  arbEmpty,
+  arbChar,
+  arbText,
+  arbLine,
+  arbFlatAlt,
+  arbCat,
+  arbNest,
+  arbUnion,
+  arbColumn,
+  arbWithPageWidth,
+  arbNesting,
+  arbAnnotated
+)


### PR DESCRIPTION
This PR adds tests for the `Core` module. We may want to consider moving these tests to a `Core` folder in the `test` directory when we start testing the `Terminal` module. We will also need to decide if we are going to test the `Annotation`-related combinators directly in `Core` or if we just test them in `Terminal` since `Terminal` makes heavy used of `Annotation`s.