### PR TITLE
Add DocTree to the package config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,35 +1,41 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-      {
-        "type": "node",
-        "request": "launch",
-        "name": "Jest All",
-        "program": "${workspaceFolder}/node_modules/.bin/jest",
-        "args": ["--runInBand"],
-        "console": "integratedTerminal",
-        "internalConsoleOptions": "neverOpen",
-        "disableOptimisticBPs": true,
-        "windows": {
-          "program": "${workspaceFolder}/node_modules/jest/bin/jest",
-        }
-      },
-      {
-        "type": "node",
-        "request": "launch",
-        "name": "Jest Current File",
-        "program": "${workspaceFolder}/node_modules/.bin/jest",
-        "args": [
-          "${fileBasenameNoExtension}",
-          "--config",
-          "jest.config.js"
-        ],
-        "console": "integratedTerminal",
-        "internalConsoleOptions": "neverOpen",
-        "disableOptimisticBPs": true,
-        "windows": {
-          "program": "${workspaceFolder}/node_modules/jest/bin/jest",
-        }
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest All",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["--runInBand"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
       }
-    ]
-  }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest Current File",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["${fileBasenameNoExtension}", "--config", "jest.config.js"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+      }
+    },
+    {
+      "type": "pwa-node",
+      "request": "launch",
+      "name": "Effect-TS - Printer Current File",
+      "runtimeArgs": ["-r", "ts-node/register"],
+      "args": ["${file}"],
+      "env": {
+        "TS_NODE_PROJECT": "${workspaceFolder}/packages/printer/tsconfig.debug.json"
+      }
+    }
+  ]
+}

--- a/packages/printer/package.json
+++ b/packages/printer/package.json
@@ -42,6 +42,7 @@
       "Terminal",
       "Terminal/Color",
       "Terminal/Layer",
+      "Terminal/Render",
       "Terminal/SGR",
       "Terminal/Style"
     ]

--- a/packages/printer/package.json
+++ b/packages/printer/package.json
@@ -25,8 +25,7 @@
   },
   "sideEffects": false,
   "peerDependencies": {
-    "@effect-ts/core": "^0.43.7",
-    "fast-check": ">= 2.14.0"
+    "@effect-ts/core": "^0.43.7"
   },
   "config": {
     "side": [],
@@ -34,6 +33,7 @@
       "Core",
       "Core/Doc",
       "Core/DocStream",
+      "Core/DocTree",
       "Core/Flatten",
       "Core/Layout",
       "Core/Optimize",

--- a/packages/printer/src/Core/Doc/index.ts
+++ b/packages/printer/src/Core/Doc/index.ts
@@ -1780,9 +1780,9 @@ export function list<A>(docs: Array<Doc<A>>): Doc<A> {
   return group(
     encloseSep_(
       docs,
-      flatAlt_(char("[ "), lbracket),
-      flatAlt_(char(" ]"), rbracket),
-      char(", ")
+      flatAlt_(text("[ "), lbracket),
+      flatAlt_(text(" ]"), rbracket),
+      text(", ")
     )
   )
 }
@@ -1808,9 +1808,9 @@ export function tupled<A>(docs: Array<Doc<A>>): Doc<A> {
   return group(
     encloseSep_(
       docs,
-      flatAlt_(char("( "), lparen),
-      flatAlt_(char(" )"), rparen),
-      char(", ")
+      flatAlt_(text("( "), lparen),
+      flatAlt_(text(" )"), rparen),
+      text(", ")
     )
   )
 }

--- a/packages/printer/src/Core/Layout/index.ts
+++ b/packages/printer/src/Core/Layout/index.ts
@@ -407,9 +407,9 @@ function fitsSmartRec<A>(
           fitsSmartRec(x.stream, w - x.text.length, minNestingLevel, lineWidth)
         )
       case "LineStream": {
-        if (minNestingLevel > x.indentation) return true
+        if (minNestingLevel >= x.indentation) return true
         return yield* _(
-          fitsSmartRec(x.stream, x.indentation - lineWidth, minNestingLevel, lineWidth)
+          fitsSmartRec(x.stream, lineWidth - x.indentation, minNestingLevel, lineWidth)
         )
       }
       case "PushAnnotationStream":

--- a/packages/printer/src/Core/Optimize/index.ts
+++ b/packages/printer/src/Core/Optimize/index.ts
@@ -69,7 +69,6 @@ function optimizeRec<A>(x: Doc<A>, depth: FusionDepth): IO.IO<Doc<A>> {
         if (D.isEmpty(x.right)) {
           return yield* _(optimizeRec(x.left, depth))
         }
-
         // String documents
         if (D.isChar(x.left) && D.isChar(x.right)) {
           return D.text(x.left.char + x.right.char)
@@ -100,7 +99,7 @@ function optimizeRec<A>(x: Doc<A>, depth: FusionDepth): IO.IO<Doc<A>> {
           const inner = yield* _(optimizeRec(D.cat_(x.left, x.right.left), depth))
           return yield* _(optimizeRec(D.cat_(inner, x.right.right), depth))
         }
-        if (D.isCat(x.left) && D.isChar(x.right)) {
+        if (D.isCat(x.left) && D.isChar(x.left.right)) {
           const inner = yield* _(optimizeRec(D.cat_(x.left.right, x.right), depth))
           return yield* _(optimizeRec(D.cat_(x.left.left, inner), depth))
         }

--- a/packages/printer/src/Core/Optimize/index.ts
+++ b/packages/printer/src/Core/Optimize/index.ts
@@ -108,18 +108,19 @@ function optimizeRec<A>(x: Doc<A>, depth: FusionDepth): IO.IO<Doc<A>> {
           const inner = yield* _(optimizeRec(D.cat_(x.left.right, x.right), depth))
           return yield* _(optimizeRec(D.cat_(x.left.left, inner), depth))
         }
-        const inner = D.cat_(
+        return D.cat_(
           yield* _(optimizeRec(x.left, depth)),
           yield* _(optimizeRec(x.right, depth))
         )
-        return yield* _(optimizeRec(inner, depth))
       }
       case "Nest": {
         if (D.isEmpty(x.doc)) return x.doc
         if (D.isChar(x.doc)) return x.doc
         if (D.isText(x.doc)) return x.doc
         if (D.isNest(x.doc)) {
-          return yield* _(optimizeRec(D.nest_(x.doc, x.indent + x.doc.indent), depth))
+          return yield* _(
+            optimizeRec(D.nest_(x.doc.doc, x.indent + x.doc.indent), depth)
+          )
         }
         if (x.indent === 0) return yield* _(optimizeRec(x.doc, depth))
         return D.nest_(yield* _(optimizeRec(x.doc, depth)), x.indent)

--- a/packages/printer/test/optimize.test.ts
+++ b/packages/printer/test/optimize.test.ts
@@ -22,9 +22,8 @@ describe("Optimize", () => {
     expect(unfused).toHaveProperty(["left", "right", "char"], "c")
     expect(unfused).toHaveProperty(["right", "char"], "d")
 
-    // Fused document will result in a single `Cat` document with two branches
-    // containing the concatenated characters in each branch of the previous
-    // unfused document
+    // Fused document will have be a single text document combining each
+    // individual char document together
     expect(fused).toHaveProperty("text", "abcd")
   })
 

--- a/packages/printer/tsconfig.debug.json
+++ b/packages/printer/tsconfig.debug.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "ts-node": {
+    "compiler": "ttypescript"
+  },
+  "compilerOptions": {
+    "strict": true,
+    "removeComments": false,
+    "plugins": [
+      {
+        "transform": "@effect-ts/tracing-plugin"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
I had forgotten to add the `DocTree` module to the `config` field in the `package.json`, which leads to import failure when attempting to do `import * as DocTree from '@effect-ts/printer/Core/DocTree`. 

This PR fixes that issue and removes an unnecessary peer dependency (i.e. `fast-check`).